### PR TITLE
Add semicolon

### DIFF
--- a/toolbox/lib/@Poly/adjust_degree.m
+++ b/toolbox/lib/@Poly/adjust_degree.m
@@ -15,7 +15,7 @@ function adjust_degree( self )
   end
   if order < self.m_order
     if order > 0
-      self.m_coeffs = self.m_coeffs(1:order)
+      self.m_coeffs = self.m_coeffs(1:order);
     else
       self.m_coeffs = zeros(1,0);
     end


### PR DESCRIPTION
Terminate statement with semicolon to suppress output (in functions)

For example
```matlab
S=Sturm();
P=Poly([1 1 0]);
S.build(P);
```
will produce output
```
self = 
   Poly with no properties
```
but this output shouldn't appear.